### PR TITLE
Current Parse JS url is not working

### DIFF
--- a/index.html
+++ b/index.html
@@ -477,7 +477,7 @@ STA $0202
 		</script>
 
 		<!-- <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script> -->
-		<script src="//www.parsecdn.com/js/parse-1.6.7.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/parse/1.6.7/parse.min.js"></script>
 		<script src="js/es5-shim.js"></script>
 		<script src="js/assembler.js"></script>
 		<script src="js/filehandler.js"></script>


### PR DESCRIPTION
Fix old not working url for loading Parse JS library